### PR TITLE
Add login body

### DIFF
--- a/agent-discoveries-backend/src/routes/user.test.ts
+++ b/agent-discoveries-backend/src/routes/user.test.ts
@@ -75,6 +75,16 @@ describe('The login route', () => {
     expect(response.statusCode).toBe(200)
   })
 
+  it('Returns the username when successful', async () => {
+    const response = await request(server)
+      .post('/user/login')
+      .set('Content-Type', 'application/json')
+      .send(
+        JSON.stringify({ username: 'test_user', password: 'password' }),
+      )
+    expect(response.body).toEqual({ username: 'test_user' })
+  })
+
   it('Sets session when successful', async () => {
     const response = await request(server)
       .post('/user/login')

--- a/agent-discoveries-backend/src/routes/user.ts
+++ b/agent-discoveries-backend/src/routes/user.ts
@@ -40,7 +40,7 @@ function createRouter(db: Knex) {
         await db.select().from<User>('users').where({ username })
       )[0]
 
-      res.status(200).send()
+      res.status(200).json({ username }).send()
     } catch (e) {
       res.status(400).send()
     }


### PR DESCRIPTION
Added the username to the body of the login endpoint response. It now looks like this:

```json
{
  "username": "test_user"
}
```